### PR TITLE
Change git submodule to point to the https url

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "cli/thor"]
 	path = cli/thor
-	url = git@github.com:erikhuda/thor.git
+	url = https://github.com/erikhuda/thor.git


### PR DESCRIPTION
so brew install doesn't blow up if you don't have github public ssh key setup