### PR TITLE
Feature: support multiple shares

### DIFF
--- a/cli/dinghy/unfs.rb
+++ b/cli/dinghy/unfs.rb
@@ -6,6 +6,10 @@ require 'dinghy/plist'
 class Unfs
   include RootPlist
 
+  def initialize(dir=HOME)
+    @dir = dir
+  end
+
   def up
     super
     wait_for_unfs
@@ -32,7 +36,7 @@ class Unfs
   end
 
   def mount_dir
-    HOME
+    return @dir
   end
 
   def plist_name

--- a/cli/dinghy/vagrant.rb
+++ b/cli/dinghy/vagrant.rb
@@ -56,7 +56,7 @@ https://www.vagrantup.com
 
   def mount(unfs)
     puts "Mounting NFS #{unfs.mount_dir}"
-    ssh("sudo mount -t nfs #{HOST_IP}:#{unfs.mount_dir} #{unfs.mount_dir} -o nfsvers=3,udp,mountport=19321,port=19321,nolock,hard,intr")
+    ssh("sudo umount #{unfs.mount_dir} 2> /dev/null; sudo mkdir -p #{unfs.mount_dir}; sudo chown docker #{unfs.mount_dir}; sudo mount -t nfs #{HOST_IP}:#{unfs.mount_dir} #{unfs.mount_dir} -o nfsvers=3,udp,mountport=19321,port=19321,nolock,hard,intr")
   end
 
   def halt

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -54,15 +54,4 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     sudo /etc/init.d/services/crond start
     echo '*/5 * * * * /usr/local/bin/ntpclient -s -h pool.ntp.org' | sudo crontab -
   EOT
-
-  # Mount the NFS volume from our own unfs daemon
-  config.vm.provision :shell, run: "always" do |s|
-    mount_dir = ENV.fetch("HOME")
-    s.inline = <<-EOT
-      echo Preparing #{mount_dir} NFS mount
-      sudo umount #{mount_dir} 2> /dev/null
-      sudo mkdir -p #{mount_dir}
-      sudo chown docker #{mount_dir}
-    EOT
-  end
 end


### PR DESCRIPTION
This PR adds support for multiple shares to dinghy. They are now organized in a single location (`dinghy-nfs-exports` file) - each share added here will be shared with the vm automatically.
This allows for setups where you'd want access to any directory in the vm that is not child of your user's home.
We use it for sharing code on a single machine and also for storing code outside the user's home.

**Note**: for the *default* use-case (i.e. only the user's home is shared) this will add overhead, as the unfsd is now restarted once (service is brought up, then share is added and service will restart).