### PR TITLE
dinghy shellinit command

### DIFF
--- a/cli/cli.rb
+++ b/cli/cli.rb
@@ -97,6 +97,11 @@ class DinghyCLI < Thor
     puts "VM base box updated, run `dinghy up` to re-create the VM"
   end
 
+  desc "shellinit", "returns env variables to set, should be run like $(dinghy shellinit)"
+  def shellinit
+    CheckEnv.new.print
+  end
+
   map "-v" => :version
   desc "version", "display dinghy version"
   def version

--- a/cli/dinghy/check_env.rb
+++ b/cli/dinghy/check_env.rb
@@ -2,11 +2,11 @@ require 'dinghy/constants'
 
 class CheckEnv
   def run
-    if expected.all? { |name,value| ENV[name] == value }
+    if set?
       puts "Your environment variables are already set correctly."
     else
       puts "To connect the Docker client to the Docker daemon, please set:"
-      expected.each { |name,value| puts "    export #{name}=#{value}" }
+      print
     end
   end
 
@@ -16,5 +16,13 @@ class CheckEnv
       "DOCKER_CERT_PATH" => "#{HOME}/.dinghy/certs",
       "DOCKER_TLS_VERIFY" => "1",
     }
+  end
+
+  def print
+    expected.each { |name,value| puts "    export #{name}=#{value}" }
+  end
+
+  def set?
+    expected.all? { |name,value| ENV[name] == value }
   end
 end


### PR DESCRIPTION
adds dinghy shellinit command that can be used like the boot2docker shellinit command to sets the environment variables in your shell:
```
$(dinghy shellinit)
```