### PR TITLE
Make mount directories configurable

### DIFF
--- a/cli/dinghy/unfs.rb
+++ b/cli/dinghy/unfs.rb
@@ -31,8 +31,12 @@ class Unfs
     end
   end
 
-  def mount_dir
-    HOME
+  def host_mount_dir
+    ENV['DINGHY_HOST_MOUNT_DIR'] || HOME
+  end
+
+  def guest_mount_dir
+    ENV['DINGHY_GUEST_MOUNT_DIR'] || HOME
   end
 
   def plist_name

--- a/cli/dinghy/vagrant.rb
+++ b/cli/dinghy/vagrant.rb
@@ -55,8 +55,8 @@ https://www.vagrantup.com
   end
 
   def mount(unfs)
-    puts "Mounting NFS #{unfs.mount_dir}"
-    ssh("sudo mount -t nfs #{HOST_IP}:#{unfs.mount_dir} #{unfs.mount_dir} -o nfsvers=3,udp,mountport=19321,port=19321,nolock,hard,intr")
+    puts "Mounting NFS #{unfs.guest_mount_dir}"
+    ssh("sudo mount -t nfs #{HOST_IP}:#{unfs.host_mount_dir} #{unfs.guest_mount_dir} -o nfsvers=3,udp,mountport=19321,port=19321,nolock,hard,intr")
   end
 
   def halt

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -58,7 +58,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   # Mount the NFS volume from our own unfs daemon
   config.vm.provision :shell, run: "always" do |s|
-    mount_dir = ENV.fetch("HOME")
+    mount_dir = ENV['DINGHY_GUEST_MOUNT_DIR'] || ENV.fetch("HOME")
     s.inline = <<-EOT
       echo Preparing #{mount_dir} NFS mount
       sudo umount #{mount_dir} 2> /dev/null


### PR DESCRIPTION
This can be useful to ensure that the mount point is predictable on the boot2docker host, for passing along to tools like docker-compose.