### PR TITLE
Copy dinghy-nfs-exports to ~/.dinghy

### DIFF
--- a/dinghy.rb
+++ b/dinghy.rb
@@ -28,6 +28,7 @@ class Dinghy < Formula
   def install
     inreplace("dinghy-nfs-exports") do |s|
       s.gsub!("%HOME%", user_home_dir)
+      s.gsub!("%HOME_DINGHY%", "#{user_home_dir}/.dinghy")
       s.gsub!("%UID%", Process.uid.to_s)
       s.gsub!("%GID%", Process.gid.to_s)
     end
@@ -40,7 +41,11 @@ class Dinghy < Formula
       s.gsub!("%ETC%", prefix/"etc", false)
     end
 
-    (prefix/"etc").install "dinghy-nfs-exports", *PLISTS
+    # Install nfs exports file to ~/.dinghy
+    ("#{user_home_dir}/.dinghy").install "dinghy-nfs-exports"
+
+    # install plits
+    (prefix/"etc").install *PLISTS
 
     FileUtils.mkdir_p(var/"dinghy/vagrant")
     FileUtils.cp("vagrant/Vagrantfile", var/"dinghy/vagrant/Vagrantfile")

--- a/dinghy.rb
+++ b/dinghy.rb
@@ -28,7 +28,6 @@ class Dinghy < Formula
   def install
     inreplace("dinghy-nfs-exports") do |s|
       s.gsub!("%HOME%", user_home_dir)
-      s.gsub!("%HOME_DINGHY%", "#{user_home_dir}/.dinghy")
       s.gsub!("%UID%", Process.uid.to_s)
       s.gsub!("%GID%", Process.gid.to_s)
     end
@@ -37,12 +36,15 @@ class Dinghy < Formula
     # controls the loading and unloading of its own plists.
     inreplace(PLISTS) do |s|
       s.gsub!("%HOME%", user_home_dir, false)
+      s.gsub!("%HOME_DINGHY%", "#{user_home_dir}/.dinghy", false)
       s.gsub!("%HOMEBREW_PREFIX%", HOMEBREW_PREFIX, false)
       s.gsub!("%ETC%", prefix/"etc", false)
     end
 
-    # Install nfs exports file to ~/.dinghy
-    ("#{user_home_dir}/.dinghy").install "dinghy-nfs-exports"
+    # Install nfs exports file to ~/.dinghy if it is missing
+    unless(File.file?("#{user_home_dir}/.dinghy/dinghy-nfs-exports"))
+        FileUtils.cp("dinghy-nfs-exports", "#{user_home_dir}/.dinghy")
+    end
 
     # install plits
     (prefix/"etc").install *PLISTS

--- a/dinghy.unfs.plist
+++ b/dinghy.unfs.plist
@@ -10,7 +10,7 @@
   <array>
     <string>%HOMEBREW_PREFIX%/sbin/unfsd</string>
     <string>-e</string>
-    <string>%ETC%/dinghy-nfs-exports</string>
+    <string>%HOME_DINGHY%/dinghy-nfs-exports</string>
     <string>-n</string>
     <string>19321</string>
     <string>-m</string>


### PR DESCRIPTION
Right now there is no convenient way to add additional nfs shares to dinghy-nfs-exports file without breaking upgradeability.

So this Pull-Request updates the brew install script so that it copies the dinghy-nfs-export to the users home directory if the file is missing.
Furthermore the unfs.plist entry is updated accordingly.

I am no ruby expert so one still has to mount any additional shares using:
```shell
dinghy ssh "sudo mount -t nfs 192.168.42.1:{{SHARE}} {{MOUNT_POINT}} -o nfsvers=3,udp,mountport=19321,port=19321,nolock,hard,intr"
```
Maybe it is possible to automate this step further.

For me i created a shell script to dinghy up and add further commands.