### PR TITLE
Create the .dinghy dir if it is missing

### DIFF
--- a/dinghy.rb
+++ b/dinghy.rb
@@ -41,6 +41,11 @@ class Dinghy < Formula
       s.gsub!("%ETC%", prefix/"etc", false)
     end
 
+    # Create the .dinghy dir if it is missing
+    unless(File.directory?("#{user_home_dir}/.dinghy"))
+        FileUtils.mkdir_p("#{user_home_dir}/.dinghy")
+    end
+
     # Install nfs exports file to ~/.dinghy if it is missing
     unless(File.file?("#{user_home_dir}/.dinghy/dinghy-nfs-exports"))
         FileUtils.cp("dinghy-nfs-exports", "#{user_home_dir}/.dinghy")


### PR DESCRIPTION
I'm totally new to homebrew formulae, but it seems the `dinghy-nfs-exports` file was getting copied to `~/.dinghy` when I installed as the `~/.dinghy` dir didn't exist.