### PR TITLE
Install fsevents_to_vm in /usr/local/bin

### DIFF
--- a/cli/dinghy/fsevents_to_vm.rb
+++ b/cli/dinghy/fsevents_to_vm.rb
@@ -39,7 +39,7 @@ class FseventsToVm
     %x{/System/Library/Frameworks/Ruby.framework/Versions/Current/usr/bin/gem list -i -v '#{VERSION}' fsevents_to_vm}
     return if $?.success? and File.exists? BIN_PATH
     puts "Installing fsevents_to_vm, this will require sudo"
-    system!("installing", "sudo", "/System/Library/Frameworks/Ruby.framework/Versions/Current/usr/bin/gem", "install", "--no-rdoc", "--no-ri", "fsevents_to_vm", "-v", VERSION)
+    system!("installing", "sudo", "/System/Library/Frameworks/Ruby.framework/Versions/Current/usr/bin/gem", "install", "-n", "/usr/local/bin", "--no-rdoc", "--no-ri", "fsevents_to_vm", "-v", VERSION)
   end
 
   def increase_inotify_limit


### PR DESCRIPTION
This avoid some strange permission error on some El Capitain setup (rvm or other ruby version manager).