### PR TITLE
check if unfs.guest_mount_dir is mounted...

### DIFF
--- a/cli/dinghy/machine.rb
+++ b/cli/dinghy/machine.rb
@@ -68,7 +68,7 @@ class Machine
     # Remove the existing vbox/vmware shared folder. There isn't an option yet
     # in docker-machine to skip creating the shared folder in the first place.
 
-    ssh("if [ $(grep -c #{Shellwords.escape(unfs.guest_mount_dir.to_s)} /proc/mounts) -gt 0 ]; then sudo umount #{unfs.guest_mount_dir} || true; fi;")
+    ssh("if [ $(grep -c #{Shellwords.escape('/Users[^/]')} /proc/mounts) -gt 0 ]; then sudo umount /Users || true; fi;")
 
     ssh("sudo mkdir -p #{unfs.guest_mount_dir}")
     ssh("sudo mount -t nfs #{host_ip}:#{unfs.host_mount_dir} #{unfs.guest_mount_dir} -o nfsvers=3,udp,mountport=19321,port=19321,nolock,hard,intr")

--- a/cli/dinghy/machine.rb
+++ b/cli/dinghy/machine.rb
@@ -1,5 +1,6 @@
 require 'dinghy/constants'
 require 'json'
+require 'shellwords'
 
 class Machine
   def create(options = {})
@@ -66,7 +67,8 @@ class Machine
     puts "Mounting NFS #{unfs.guest_mount_dir}"
     # Remove the existing vbox/vmware shared folder. There isn't an option yet
     # in docker-machine to skip creating the shared folder in the first place.
-    ssh("sudo umount /Users || true")
+
+    ssh("if [ $(grep -c #{Shellwords.escape(unfs.guest_mount_dir.to_s)} /proc/mounts) -gt 0 ]; then sudo umount #{unfs.guest_mount_dir} || true; fi;")
 
     ssh("sudo mkdir -p #{unfs.guest_mount_dir}")
     ssh("sudo mount -t nfs #{host_ip}:#{unfs.host_mount_dir} #{unfs.guest_mount_dir} -o nfsvers=3,udp,mountport=19321,port=19321,nolock,hard,intr")


### PR DESCRIPTION
...before attempting to unmout it.

There's probably a better way to do this that doesn't require another `require` but my Ruby skills are basic.