### PR TITLE
fix compatibility with docker-machine 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 - Fix `dinghy` binary name in the help text.
 - Switched from using launchd to managing our own daemons.
 - Added better error handling and logging for the fsev/dns/nfs daemons.
+- Fix compatibility with docker-machine 0.5.0
 
 ## 4.0.5 - 2015-10-29
 

--- a/cli/dinghy/machine.rb
+++ b/cli/dinghy/machine.rb
@@ -18,13 +18,15 @@ class Machine
   end
 
   def up
-    out, err = System.capture_output {
-      system("start", machine_name)
-    }
+    unless running?
+      out, err = System.capture_output {
+        system("start", machine_name)
+      }
 
-    if System.command_failed?
-      $stderr.puts err
-      raise("There was an error bringing up the VM. Dinghy cannot continue.")
+      if System.command_failed?
+        $stderr.puts err
+        raise("There was an error bringing up the VM. Dinghy cannot continue.")
+      end
     end
 
     Ssh.new(self).write_ssh_config!
@@ -43,7 +45,12 @@ class Machine
   end
 
   def store_path
-    inspect['StorePath']
+    driver = inspect['Driver']
+    if driver.key?('StorePath')
+      File.join(driver['StorePath'], 'machines', driver['MachineName'])
+    else
+      inspect['StorePath']
+    end
   end
 
   def inspect


### PR DESCRIPTION
docker-machine changed the inspect output, removing the `StorePath`
root-level key and adding a `Driver > StorePath` (which doesn't include
the full path to the machine as before)

docker-machine also changed the exit status for `docker-machine start`
if the machine is already running (now exits with 1)

fixes #99 and #100