### PR TITLE
Never hardcode the path for Homebrew

### DIFF
--- a/cli/dinghy/constants.rb
+++ b/cli/dinghy/constants.rb
@@ -5,13 +5,13 @@ MEM_DEFAULT=2048
 CPU_DEFAULT=1
 DISK_DEFAULT=20_000
 
+BREW = Pathname.new(`brew --prefix`.strip)
+
 # makes local dev easier
 if $0 =~ /bin\/_dinghy_command/ || $0 =~ /rspec/
-  BREW = Pathname.new('/usr/local')
   DINGHY = Pathname.new(File.expand_path("../..", File.dirname(__FILE__)))
   VAR = Pathname.new(File.expand_path("../../local/var", File.dirname(__FILE__)))
 else
-  BREW = Pathname.new(`brew --prefix`.strip)
   DINGHY = BREW+"opt/dinghy"
   VAR = BREW+"var/dinghy"
 end


### PR DESCRIPTION
Having issues running dinghy when using a non-standard homebrew install path (`/opt/boxen/homebrew` in my case).