### PR TITLE
When using env var DINGHY_HOST_MOUNT_DIR the .dinghy/machine-nfs-expo…

### DIFF
--- a/cli/dinghy/unfs.rb
+++ b/cli/dinghy/unfs.rb
@@ -62,7 +62,7 @@ class Unfs
 
   def exports_body
     <<-BODY.gsub(/^    /, '')
-    "#{HOME}" #{machine.vm_ip}(rw,all_squash,anonuid=#{Process.uid},anongid=#{Process.gid})
+    "#{host_mount_dir}" #{machine.vm_ip}(rw,all_squash,anonuid=#{Process.uid},anongid=#{Process.gid})
     BODY
   end
 


### PR DESCRIPTION
When using env var DINGHY_HOST_MOUNT_DIR the .dinghy/machine-nfs-exports-dinghy file does not contain the value from that env-var, and will cause unfs to fail with permission denied error.