### PR TITLE
Adds support for configurable dev domain

### DIFF
--- a/cli/cli.rb
+++ b/cli/cli.rb
@@ -217,6 +217,9 @@ class DinghyCLI < Thor
       fsevents.up
     end
     dns = Dnsmasq.new(machine)
+    if (preferences[:dinghy_domain])
+        dns.dinghy_domain = preferences[:dinghy_domain]
+    end
     dns.up
     proxy = options[:proxy] || (options[:proxy].nil? && !proxy_disabled?)
     if proxy

--- a/cli/cli.rb
+++ b/cli/cli.rb
@@ -217,9 +217,7 @@ class DinghyCLI < Thor
       fsevents.up
     end
     dns = Dnsmasq.new(machine)
-    if (preferences[:dinghy_domain])
-        dns.dinghy_domain = preferences[:dinghy_domain]
-    end
+    dns.dinghy_domain = preference[:dinghy_domain] if preferences[:dinghy_domain] 
     dns.up
     proxy = options[:proxy] || (options[:proxy].nil? && !proxy_disabled?)
     if proxy

--- a/cli/dinghy/dnsmasq.rb
+++ b/cli/dinghy/dnsmasq.rb
@@ -11,7 +11,7 @@ class Dnsmasq
 
   def initialize(machine)
     @machine = machine
-    @dinghy_domain = "docker"
+    self.dinghy_domain = "docker"
     @resolver_file = RESOLVER_DIR.join(@dinghy_domain)
   end
 

--- a/cli/dinghy/dnsmasq.rb
+++ b/cli/dinghy/dnsmasq.rb
@@ -7,10 +7,17 @@ class Dnsmasq
   RESOLVER_DIR = Pathname("/etc/resolver")
   RESOLVER_FILE = RESOLVER_DIR.join("docker")
 
-  attr_reader :machine
+  attr_reader :machine, :resolver_file, :dinghy_domain
 
   def initialize(machine)
     @machine = machine
+    @dinghy_domain = "docker"
+    @resolver_file = RESOLVER_DIR.join(@dinghy_domain)
+  end
+
+  def dinghy_domain=(dinghy_domain)
+    @dinghy_domain = dinghy_domain
+    @resolver_file = RESOLVER_DIR.join(@dinghy_domain)
   end
 
   def up
@@ -32,14 +39,14 @@ class Dnsmasq
     Tempfile.open('dinghy-dnsmasq') do |f|
       f.write(resolver_contents)
       f.close
-      system!("creating #{RESOLVER_FILE}", "sudo", "cp", f.path, RESOLVER_FILE)
-      system!("creating #{RESOLVER_FILE}", "sudo", "chmod", "644", RESOLVER_FILE)
+      system!("creating #{@resolver_file}", "sudo", "cp", f.path, @resolver_file)
+      system!("creating #{@resolver_file}", "sudo", "chmod", "644", @resolver_file)
     end
     system!("restarting mDNSResponder", "sudo", "killall", "mDNSResponder")
   end
 
   def resolver_configured?
-    RESOLVER_FILE.exist? && File.read(RESOLVER_FILE) == resolver_contents
+    @resolver_file.exist? && File.read(@resolver_file) == resolver_contents
   end
 
   def resolver_contents; <<-EOS.gsub(/^    /, '')
@@ -59,7 +66,7 @@ class Dnsmasq
       "--port=19322",
       "--bind-interfaces",
       "--no-resolv",
-      "--address=/.docker/#{machine.vm_ip}"
+      "--address=/.#{dinghy_domain}/#{machine.vm_ip}"
     ]
   end
 end

--- a/spec/dnsmasq_spec.rb
+++ b/spec/dnsmasq_spec.rb
@@ -1,0 +1,21 @@
+RSpec.describe Dnsmasq do
+  let(:dnsmasq_instance) {
+    machine = Class.new do
+      def vm_ip 
+        "192.168.99.100"
+      end
+    end
+    Dnsmasq.new(machine.new)
+  }
+
+  it 'defaults to `docker` as domain when no preference exists' do
+    expect(dnsmasq_instance.dinghy_domain).to eq "docker"
+    expect(dnsmasq_instance.send(:command)[-1]).to eq "--address=/.docker/192.168.99.100"
+  end
+  
+  it 'sets the domain to the one set in the preferences' do
+    dnsmasq_instance.dinghy_domain = "dev"
+    expect(dnsmasq_instance.dinghy_domain).to eq "dev"
+    expect(dnsmasq_instance.send(:command)[-1]).to eq "--address=/.dev/192.168.99.100"
+  end
+end

--- a/spec/dnsmasq_spec.rb
+++ b/spec/dnsmasq_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe Dnsmasq do
   let(:dnsmasq_instance) {
+    # Mocking the machine class
     machine = Class.new do
       def vm_ip 
         "192.168.99.100"
@@ -10,12 +11,14 @@ RSpec.describe Dnsmasq do
 
   it 'defaults to `docker` as domain when no preference exists' do
     expect(dnsmasq_instance.dinghy_domain).to eq "docker"
-    expect(dnsmasq_instance.send(:command)[-1]).to eq "--address=/.docker/192.168.99.100"
+    expect(dnsmasq_instance.resolver_file).to eq Pathname.new("/etc/resolver/docker")
+    expect(dnsmasq_instance.send(:command).last).to eq "--address=/.docker/192.168.99.100"
   end
   
   it 'sets the domain to the one set in the preferences' do
     dnsmasq_instance.dinghy_domain = "dev"
     expect(dnsmasq_instance.dinghy_domain).to eq "dev"
-    expect(dnsmasq_instance.send(:command)[-1]).to eq "--address=/.dev/192.168.99.100"
+    expect(dnsmasq_instance.resolver_file).to eq Pathname.new("/etc/resolver/dev")
+    expect(dnsmasq_instance.send(:command).last).to eq "--address=/.dev/192.168.99.100"
   end
 end


### PR DESCRIPTION
PR for #121. 

This adds support to the dinghy cli to launch dnsmasq with a custom TLD. 

The preference is stored in `preferences.yml` under the key of `:dinghy_domain`. If no key is set it will default to `docker`.

Example preferences.yml file
```ruby
---
:preferences:
  :proxy_disabled: false
  :fsevents_disabled: false
  :dinghy_domain: dev
  :create:
    provider: virtualbox
```

I've tested this on my machine and its working for me. Thoughts on implementation? 

I'm not a Ruby dev, so please let me know if there are any blatant Ruby anti-patterns/non-idiomatic things.

Also working on adding a test for this.