### PR TITLE
The dinghy ssh-config does not exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,6 @@ Commands:
   dinghy restart         # restart the VM and services
   dinghy shellinit       # returns env variables to set, should be run like $(dinghy shellinit)
   dinghy ssh [args...]   # ssh to the VM
-  dinghy ssh-config      # print ssh configuration for the VM
   dinghy status          # get VM and services status
   dinghy up              # start the Docker VM and services
   dinghy upgrade         # upgrade the boot2docker VM to the newest available


### PR DESCRIPTION
After a fresh installation of dinghy, the ssh-config command does not exist any more. It don't know if it's a feature or a bug.

<pre>
  $ dinghy ssh-config
  > Could not find command "ssh-config".
  $ dinghy version
  > Dinghy 4.2.0
</pre>