### PR TITLE
Implement support for xhyve

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ First the prerequisites:
 
 1. OS X Yosemite (10.10) (Mavericks has a known issue, see [#6](https://github.com/codekitchen/dinghy/issues/6))
 1. [Homebrew](https://github.com/Homebrew/homebrew)
-1. Either [VirtualBox](https://www.virtualbox.org), [VMware Fusion](http://www.vmware.com/products/fusion) or [xhyve](http://www.xhyve.org/)
+1. Either [VirtualBox](https://www.virtualbox.org), [VMware Fusion](http://www.vmware.com/products/fusion) or [xhyve](http://www.xhyve.org/) through the [docker-machine-driver-xhyve](https://github.com/zchee/docker-machine-driver-xhyve#install) project
 
 If using VirtualBox, version 5.0+ is strongly recommended, and you'll need the
 [VirtualBox Extension Pack](https://www.virtualbox.org/wiki/Downloads)

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ First the prerequisites:
 
 1. OS X Yosemite (10.10) (Mavericks has a known issue, see [#6](https://github.com/codekitchen/dinghy/issues/6))
 1. [Homebrew](https://github.com/Homebrew/homebrew)
-1. Either [VirtualBox](https://www.virtualbox.org) or [VMware Fusion](http://www.vmware.com/products/fusion).
+1. Either [VirtualBox](https://www.virtualbox.org), [VMware Fusion](http://www.vmware.com/products/fusion) or [xhyve](http://www.xhyve.org/)
 
 If using VirtualBox, version 5.0+ is strongly recommended, and you'll need the
 [VirtualBox Extension Pack](https://www.virtualbox.org/wiki/Downloads)
@@ -43,7 +43,7 @@ You will need to install `docker` and `docker-machine` as well, either via Homeb
 
     $ brew install docker docker-machine
 
-You can specify provider (virtualbox or vmware), memory and CPU options when creating the VM. See available options:
+You can specify provider (`virtualbox`, `vmware` or `xhyve`), memory and CPU options when creating the VM. See available options:
 
     $ dinghy help create
 

--- a/cli/cli.rb
+++ b/cli/cli.rb
@@ -35,7 +35,7 @@ class DinghyCLI < Thor
     desc: "size of the virtual disk to create, in MB (default #{DISK_DEFAULT})"
   option :provider,
     aliases: :p,
-    desc: "which docker-machine provider to use, 'virtualbox' or 'vmware'"
+    desc: "which docker-machine provider to use, 'virtualbox', 'vmware' or 'xhyve'"
   desc "create", "create the docker-machine VM"
   def create
     if machine.created?
@@ -48,7 +48,7 @@ class DinghyCLI < Thor
     create_options['provider'] = machine.translate_provider(create_options['provider'])
 
     if create_options['provider'].nil?
-      $stderr.puts("Invalid value for required option --provider. Valid values are: 'virtualbox', 'vmware'")
+      $stderr.puts("Invalid value for required option --provider. Valid values are: 'virtualbox', 'vmware' or 'xhyve'")
       exit(1)
     end
 

--- a/cli/dinghy/machine.rb
+++ b/cli/dinghy/machine.rb
@@ -133,6 +133,8 @@ class Machine
       "virtualbox"
     when "vmware", "vmware_fusion", "vmwarefusion", "vmware_desktop"
       "vmwarefusion"
+    when "xhyve"
+      "xhyve"
     else
       nil
     end

--- a/cli/dinghy/machine/create_options.rb
+++ b/cli/dinghy/machine/create_options.rb
@@ -13,6 +13,13 @@ module Machine::CreateOptions
       disk: '--vmwarefusion-disk-size',
       no_share: '--vmwarefusion-no-share',
     }.freeze,
+
+    'xhyve' => {
+      memory: '--xhyve-memory-size',
+      cpus: '--xhyve-cpu-count',
+      disk: '--xhyve-disk-size',
+      # No shared folders are created on xhyve by default
+    }.freeze,
   }.freeze
 
   def self.generate(provider, options)
@@ -22,6 +29,6 @@ module Machine::CreateOptions
       flags[:cpus], (options['cpus'] || CPU_DEFAULT).to_s,
       flags[:disk], (options['disk'] || DISK_DEFAULT).to_s,
       flags[:no_share],
-    ]
+    ].compact
   end
 end


### PR DESCRIPTION
Environment: 

```
$ brew info docker-machine
docker-machine: stable 0.6.0 (bottled), HEAD
Create Docker hosts locally and on cloud providers
https://docs.docker.com/machine
/usr/local/Cellar/docker-machine/0.5.6_1 (5 files, 36.3M)
  Poured from bottle
/usr/local/Cellar/docker-machine/0.6.0 (5 files, 36.8M) *
  Poured from bottle
From: https://github.com/Homebrew/homebrew/blob/master/Library/Formula/docker-machine.rb
==> Dependencies
Build: go ✘, automake ✘
==> Caveats
Bash completion has been installed to:
  /usr/local/etc/bash_completion.d

$ brew info xhyve
xhyve: stable 0.2.0, HEAD
xhyve, lightweight OS X virtualization solution based on FreeBSD's bhyve
https://github.com/mist64/xhyve
/usr/local/Cellar/xhyve/0.2.0 (3 files, 224.2K) *
  Built from source
From: https://github.com/Homebrew/homebrew/blob/master/Library/Formula/xhyve.rb

$ brew info docker-machine-driver-xhyve
docker-machine-driver-xhyve: stable 0.2.2 (bottled), HEAD
Docker Machine driver for xhyve
https://github.com/zchee/docker-machine-driver-xhyve
/usr/local/Cellar/docker-machine-driver-xhyve/0.2.2 (2 files, 12.2M) *
  Poured from bottle
From: https://github.com/Homebrew/homebrew/blob/master/Library/Formula/docker-machine-driver-xhyve.rb
==> Dependencies
Build: go ✘
Recommended: docker-machine ✔
==> Options
--without-docker-machine
	Build without docker-machine support
--HEAD
	Install HEAD version
```

I gave it a quick try and it seems that things are working fine. I'll continue playing with it throughout the day but it would be awesome to have someone else testing it as well :muscle: 

Cheers!