### PR TITLE
Write host_mount_dir not HOME to the exports file

### DIFF
--- a/cli/dinghy/unfs.rb
+++ b/cli/dinghy/unfs.rb
@@ -78,7 +78,7 @@ class Unfs
 
   def exports_body
     <<-BODY.gsub(/^    /, '')
-    "#{HOME}" #{machine.vm_ip}(rw,all_squash,anonuid=#{Process.uid},anongid=#{Process.gid})
+    "#{host_mount_dir}" #{machine.vm_ip}(rw,all_squash,anonuid=#{Process.uid},anongid=#{Process.gid})
     BODY
   end
 


### PR DESCRIPTION
If you set DINGHY_HOST_MOUNT_DIR now you'll find that unfs won't actually let you mount it, since it's not in the exports file. This fixes that.