### PR TITLE
Add support for parallels and boot2docker-url

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ First the prerequisites:
 
 1. OS X Yosemite (10.10) (Mavericks has a known issue, see [#6](https://github.com/codekitchen/dinghy/issues/6))
 1. [Homebrew](https://github.com/Homebrew/homebrew)
-1. Either [VirtualBox](https://www.virtualbox.org), [VMware Fusion](http://www.vmware.com/products/fusion) or [xhyve](http://www.xhyve.org/) through the [docker-machine-driver-xhyve](https://github.com/zchee/docker-machine-driver-xhyve#install) project
+1. Either [VirtualBox](https://www.virtualbox.org), [VMware Fusion](http://www.vmware.com/products/fusion), [xhyve](http://www.xhyve.org/) through the [docker-machine-driver-xhyve](https://github.com/zchee/docker-machine-driver-xhyve#install) project, or [Parallels](https://www.parallels.com/products/desktop/) through the [docker-machine-parallels](https://github.com/Parallels/docker-machine-parallels) project.
 
 If using VirtualBox, version 5.0+ is strongly recommended, and you'll need the
 [VirtualBox Extension Pack](https://www.virtualbox.org/wiki/Downloads)

--- a/cli/cli.rb
+++ b/cli/cli.rb
@@ -35,7 +35,11 @@ class DinghyCLI < Thor
     desc: "size of the virtual disk to create, in MB (default #{DISK_DEFAULT})"
   option :provider,
     aliases: :p,
-    desc: "which docker-machine provider to use, 'virtualbox', 'vmware' or 'xhyve'"
+    desc: "which docker-machine provider to use, 'virtualbox', 'vmware', 'xhyve', or parallels"
+  option :boot2docker_url,
+    type: :string,
+    aliases: :u,
+    desc: 'URL of the boot2docker image'
   desc "create", "create the docker-machine VM"
   def create
     if machine.created?
@@ -48,7 +52,7 @@ class DinghyCLI < Thor
     create_options['provider'] = machine.translate_provider(create_options['provider'])
 
     if create_options['provider'].nil?
-      $stderr.puts("Invalid value for required option --provider. Valid values are: 'virtualbox', 'vmware' or 'xhyve'")
+      $stderr.puts("Invalid value for required option --provider. Valid values are: 'virtualbox', 'vmware', 'xhyve', or 'parallels'")
       exit(1)
     end
 

--- a/cli/dinghy/machine.rb
+++ b/cli/dinghy/machine.rb
@@ -39,7 +39,11 @@ class Machine
   end
 
   def host_ip
-    vm_ip.sub(%r{\.\d+$}, '.1')
+    if provider == 'parallels'
+      vm_ip.sub(%r{\.\d+$}, '.2')
+    else
+      vm_ip.sub(%r{\.\d+$}, '.1')
+    end
   end
 
   def vm_ip
@@ -86,7 +90,7 @@ class Machine
 
   def mount(unfs)
     puts "Mounting NFS #{unfs.guest_mount_dir}"
-    # Remove the existing vbox/vmware shared folder. Machine now has flags to
+    # Remove the existing vbox/vmware/parallels shared folder. Machine now has flags to
     # skip mounting the share at all, but there's no way to apply the flag to an
     # already-created machine. So we have to continue to do this for older VMs.
     ssh("if [ $(grep -c #{Shellwords.escape('/Users[^/]')} /proc/mounts) -gt 0 ]; then sudo umount /Users || true; fi;")
@@ -135,6 +139,8 @@ class Machine
       "vmwarefusion"
     when "xhyve"
       "xhyve"
+    when "parallels", "parallels-desktop"
+      "parallels"
     else
       nil
     end

--- a/cli/dinghy/machine/create_options.rb
+++ b/cli/dinghy/machine/create_options.rb
@@ -5,6 +5,7 @@ module Machine::CreateOptions
       cpus: '--virtualbox-cpu-count',
       disk: '--virtualbox-disk-size',
       no_share: '--virtualbox-no-share',
+      boot2docker_url: '--virtualbox-boot2docker-url'
     }.freeze,
 
     'vmwarefusion' => {
@@ -12,6 +13,7 @@ module Machine::CreateOptions
       cpus: '--vmwarefusion-cpu-count',
       disk: '--vmwarefusion-disk-size',
       no_share: '--vmwarefusion-no-share',
+      boot2docker_url: '--vmwarefusion-boot2docker-url'
     }.freeze,
 
     'xhyve' => {
@@ -19,7 +21,16 @@ module Machine::CreateOptions
       cpus: '--xhyve-cpu-count',
       disk: '--xhyve-disk-size',
       # No shared folders are created on xhyve by default
+      boot2docker_url: '--xhyve-boot2docker-url'
     }.freeze,
+
+    'parallels' => {
+      memory: '--parallels-memory',
+      cpus: '--parallels-cpu-count',
+      disk: '--parallels-disk-size',
+      no_share: '--parallels-no-share',
+      boot2docker_url: '--parallels-boot2docker-url'
+    }.freeze
   }.freeze
 
   def self.generate(provider, options)
@@ -28,7 +39,12 @@ module Machine::CreateOptions
       flags[:memory], (options['memory'] || MEM_DEFAULT).to_s,
       flags[:cpus], (options['cpus'] || CPU_DEFAULT).to_s,
       flags[:disk], (options['disk'] || DISK_DEFAULT).to_s,
-      flags[:no_share],
-    ].compact
+      flags[:no_share]
+    ].compact.tap do |create_options|
+      unless options['boot2docker_url'].nil?
+        create_options << flags[:boot2docker_url]
+        create_options << options['boot2docker_url'].to_s
+      end
+    end
   end
 end

--- a/spec/create_options_spec.rb
+++ b/spec/create_options_spec.rb
@@ -10,12 +10,13 @@ RSpec.describe Machine::CreateOptions do
   end
 
   it 'generates with passed options' do
-    opts = { 'memory' => 4096, 'disk' => 40000, }
+    opts = { 'memory' => 4096, 'disk' => 40000, 'boot2docker_url' => 'alternate' }
     expect(subject.generate('vmwarefusion', opts)).to eq([
       '--vmwarefusion-memory-size', '4096',
       '--vmwarefusion-cpu-count', CPU_DEFAULT.to_s,
       '--vmwarefusion-disk-size', '40000',
       '--vmwarefusion-no-share',
+      '--vmwarefusion-boot2docker-url', 'alternate'
     ])
   end
 end


### PR DESCRIPTION
With these options I'm able to provision both a boot2docker VM and a RancherOS VM on Parallels Desktop 11 with dinghy.