### PR TITLE
Add support for defined startup containers in preferences.yml

### DIFF
--- a/cli/dinghy/composer.rb
+++ b/cli/dinghy/composer.rb
@@ -1,0 +1,40 @@
+require 'stringio'
+require 'yaml'
+require 'tempfile'
+
+require 'dinghy/machine'
+require 'dinghy/container'
+
+class Composer
+  PROJECT_NAME = 'dinghy'
+
+  attr_reader :machine, :containers
+
+  def initialize(machine,containers)
+    @machine = machine
+    @containers = containers
+  end
+
+  def up
+    puts "Starting containers: #{containers.keys.join(',')}"
+    compose_yaml = Tempfile.new('compose.yml')
+    compose_yaml.write({"version" => "2", "services" => containers}.to_yaml)
+    compose_yaml.close
+    docker.compose("-f", compose_yaml.path, "-p", PROJECT_NAME, "up", "-d")
+  end
+
+  def statuses
+    container_statuses = {}
+    containers.each do |name, container|
+      container_statuses[name] = Container.new(machine,"#{PROJECT_NAME}_#{name}_1").status
+    end
+
+    return container_statuses
+  end
+
+  private
+
+  def docker
+    @docker ||= Docker.new(machine)
+  end
+end

--- a/cli/dinghy/container.rb
+++ b/cli/dinghy/container.rb
@@ -1,0 +1,47 @@
+require 'stringio'
+
+require 'dinghy/machine'
+
+class Container
+
+  attr_reader :machine, :container_name, :image_name, :ports, :volumes
+
+  def initialize(machine,container_name,image_name=nil,ports="80:80",volumes=nil)
+    @machine = machine
+    @container_name = container_name
+    @image_name = image_name
+    @ports = ports
+    @volumes = volumes
+  end
+
+  def up
+    puts "Starting #{container_name}"
+    System.capture_output do
+      docker.exec("rm", "-fv", container_name)
+    end
+    args = []
+    volumes.each{|volume| args += ['-v',volume]}
+    args += ["-d", "-p", ports, "-e", "CONTAINER_NAME=#{container_name}", "--name", container_name, image_name]
+    docker.exec("run", *args)
+  end
+
+  def status
+    return "stopped" if !machine.running?
+
+    output, _ = System.capture_output do
+      docker.exec("inspect", "-f", "{{ .State.Running }}", container_name)
+    end
+
+    if output.strip == "true"
+      "running"
+    else
+      "stopped"
+    end
+  end
+
+  private
+
+  def docker
+    @docker ||= Docker.new(machine)
+  end
+end

--- a/cli/dinghy/docker.rb
+++ b/cli/dinghy/docker.rb
@@ -8,10 +8,12 @@ class Docker
     @check_env = check_env || CheckEnv.new(machine)
   end
 
-  def system(*command)
-    set_env do
-      Kernel.system("docker", *command)
-    end
+  def exec(*command)
+    system("docker",*command)
+  end
+
+  def compose(*command)
+    system("docker-compose",*command)
   end
 
   protected
@@ -24,5 +26,11 @@ class Docker
     yield
   ensure
     old_env.each { |k,v| ENV[k] = v }
+  end
+
+  def system(binary,*command)
+    set_env do
+      Kernel.system(binary, *command)
+    end
   end
 end

--- a/cli/dinghy/http_proxy.rb
+++ b/cli/dinghy/http_proxy.rb
@@ -1,42 +1,12 @@
-require 'stringio'
+require 'dinghy/container'
 
-require 'dinghy/machine'
-
-class HttpProxy
+class HttpProxy < Container
   CONTAINER_NAME = "dinghy_http_proxy"
   IMAGE_NAME = "codekitchen/dinghy-http-proxy:2.0.2"
-
-  attr_reader :machine
+  PORTS = "80:80"
+  VOLUMES= ["/var/run/docker.sock:/tmp/docker.sock", "/usr/local/bin/docker:/usr/local/bin/docker"]
 
   def initialize(machine)
-    @machine = machine
-  end
-
-  def up
-    puts "Starting the HTTP proxy"
-    System.capture_output do
-      docker.system("rm", "-fv", CONTAINER_NAME)
-    end
-    docker.system("run", "-d", "-p", "80:80", "-v", "/var/run/docker.sock:/tmp/docker.sock", "-v", "/usr/local/bin/docker:/usr/local/bin/docker", "-e", "CONTAINER_NAME=#{CONTAINER_NAME}", "--name", CONTAINER_NAME, IMAGE_NAME)
-  end
-
-  def status
-    return "stopped" if !machine.running?
-
-    output, _ = System.capture_output do
-      docker.system("inspect", "-f", "{{ .State.Running }}", CONTAINER_NAME)
-    end
-
-    if output.strip == "true"
-      "running"
-    else
-      "stopped"
-    end
-  end
-
-  private
-
-  def docker
-    @docker ||= Docker.new(machine)
+    super(machine,CONTAINER_NAME,IMAGE_NAME,PORTS,VOLUMES)
   end
 end

--- a/spec/docker_spec.rb
+++ b/spec/docker_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Docker do
     it 'preserves the original environment' do
       expect(Kernel).to receive(:system).with("docker", "ps").and_return "zero"
       ENV['DOCKER_HOST'] = 'myhost'
-      expect(subject.system("ps")).to eq('zero')
+      expect(subject.exec("ps")).to eq('zero')
       expect(ENV['DOCKER_HOST']).to eq('myhost')
     end
   end


### PR DESCRIPTION
Provides a method for defining startup containers (in docker compose v2 format) within the preferences.yml file.

I have several utility containers (such as postgres and redis) that I like to have always running when I bring up the VM. This change allows for these to be started as part of dinghy.

Example preferences.yml:
```
---
:preferences:
  :proxy_disabled: true
  :fsevents_disabled: false
  :create:
    provider: virtualbox
    disk: 40960
  :startup_containers:
    postgres:
      image: postgres
      ports:
      - 5432:5432
      environment:
      - VIRTUAL_HOST=postgres.docker
    redis:
      image: redis
      ports:
      - 6379:6379
      environment:
      - VIRTUAL_HOST=redis.docker
```

Open to any feedback as I see this as a nice enhancement.