### PR TITLE
Fix FS Events forwarding to xhyve VM

### DIFF
--- a/cli/dinghy/machine.rb
+++ b/cli/dinghy/machine.rb
@@ -51,7 +51,14 @@ class Machine
   end
 
   def ssh_identity_file_path
-    inspect_driver['SSHKeyPath']
+    # HACK: The xhyve driver returns this as a blank string on v0.2.2 so we
+    #       manually build the path ourselves
+    ssh_key_path = inspect_driver["SSHKeyPath"]
+    if ssh_key_path != ""
+      ssh_key_path
+    else
+      "#{store_path}/id_rsa"
+    end
   end
 
   def provider


### PR DESCRIPTION
Just noticed that today and I tracked down the root cause to a blanky `SSHKeyPath` on the VM's state that results in wrong arguments being passed on to `fsevents_to_vm`:

```
$ docker-machine create remove --driver xhyve
....
Docker is up and running!
To see how to connect your Docker Client to the Docker Engine running on
this virtual machine, run: docker-machine env remove

$ docker-machine inspect remove | grep -i sshkey
        "SSHKeyPath": "",
```

This might be something to be fixed on the driver's side but I guess it does the trick for now.