### PR TITLE
Add SSL support to dinghy

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,40 @@ web:
     VIRTUAL_HOST: myrailsapp.docker
 ```
 
+### SSL Support
+
+SSL is supported using single host certificates using naming conventions.
+
+To enable SSL, just put your certificates and privates keys in the ```HOME/.dinghy/certs``` directory 
+for any virtual hosts in use.  The certificate and keys should be named after the virtual host with a `.crt` and
+`.key` extension.  For example, a container with `VIRTUAL_HOST=foo.bar.com.docker` should have a
+`foo.bar.com.docker.crt` and `foo.bar.com.docker.key` file in the certs directory.
+
+#### How SSL Support Works
+
+The SSL cipher configuration is based on [mozilla nginx intermediate profile](https://wiki.mozilla.org/Security/Server_Side_TLS#Nginx) which
+should provide compatibility with clients back to Firefox 1, Chrome 1, IE 7, Opera 5, Safari 1,
+Windows XP IE8, Android 2.3, Java 7.  The configuration also enables HSTS, and SSL
+session caches.
+
+The behavior for the proxy is as follows:
+
+* If a container has a usable cert, port 80 will redirect to 443 for that container so that HTTPS
+is always preferred when available.
+* If the container does not have a usable cert, port 80 will be used.
+
+#### Hox to quickly generate self-signed certificates
+
+You can generate self-signed certificates using ```openssl```.
+
+``
+openssl req -x509 -newkey rsa:2048 -keyout foo.bar.com.docker.key \
+-out foo.bar.com.docker.crt -days 365 -nodes \
+-subj "/C=US/ST=Oregon/L=Portland/O=Company Name/OU=Org/CN=foo.bar.com.docker" 
+````
+
+To prevent your browser to emit warning regarding self-signed certificates, you can install them on your system as trusted certificates.
+
 ## Preferences
 
 Dinghy creates a preferences file under ```HOME/.dinghy/preferences.yml```, which can be used to override default options. This is an example of the default generated preferenes:

--- a/cli/dinghy.rb
+++ b/cli/dinghy.rb
@@ -31,6 +31,10 @@ module Dinghy
     home+'.dinghy'
   end
 
+  def self.home_dinghy_certs
+    home+'.dinghy/certs'
+  end
+
   def self.run_checks
     create_dinghy_dirs
     docker_cmd_checks
@@ -46,6 +50,9 @@ module Dinghy
     # Create the .dinghy dir if it is missing
     unless Dinghy.home_dinghy.directory?
       Dinghy.home_dinghy.mkdir
+    end
+    unless Dinghy.home_dinghy_certs.directory?
+      Dinghy.home_dinghy_certs.mkdir
     end
     unless Dinghy.var.directory?
       FileUtils.mkdir_p Dinghy.var

--- a/cli/dinghy/http_proxy.rb
+++ b/cli/dinghy/http_proxy.rb
@@ -1,6 +1,7 @@
 require 'stringio'
 
 require 'dinghy/machine'
+require 'dinghy/constants'
 
 class HttpProxy
   CONTAINER_NAME = "dinghy_http_proxy"
@@ -20,8 +21,9 @@ class HttpProxy
     end
     docker.system("run", "-d",
       "-p", "80:80",
+      "-p", "443:443",
       "-v", "/var/run/docker.sock:/tmp/docker.sock",
-      "-v", "#{CONTAINER_NAME}_certs:/etc/nginx/certs",
+      "-v", Dinghy.home_dinghy.to_s+"/certs:/etc/nginx/certs",
       "-e", "CONTAINER_NAME=#{CONTAINER_NAME}",
       "-e", "DOMAIN_TLD=#{@dinghy_domain}",
       "--name", CONTAINER_NAME, IMAGE_NAME)


### PR DESCRIPTION
This is a simple patch in addition to dinghy_http_proxy to get basic SSL support in dinghy.

Not all features of jwilder/nginx-proxy are supported, but single host certificate file works.

Hope it helps.

Regards,

Mickaël