### PR TITLE
Implement support for custom nfs export options.

### DIFF
--- a/cli/cli.rb
+++ b/cli/cli.rb
@@ -205,7 +205,7 @@ class DinghyCLI < Thor
 
   def start_services
     machine.up
-    unfs.up
+    unfs.up(preferences[:custom_nfs_export_options])
     if unfs.wait_for_unfs
       machine.mount(unfs)
     else


### PR DESCRIPTION
Hi there!

This PR implements the ability for users to specify custom nfs export options that override the defaults in their preferences.yml file. This is useful because it allows me to opt-out of the root squashing behavior. Some of the containers that I'm running for work legitimately need root and this allows me to give it to them.

Let me know if there are any questions / changes that I need to make to have this included.