### PR TITLE
use docker-machine --virtualbox-host-dns-resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 - Use the new dinghy-http-proxy that contains the DNS resolver.
 - Set VirtualBox DNS options on each start, rather than once at VM create.
 - Support [`HTTPS_METHOD`](https://github.com/jwilder/nginx-proxy/pull/298) env var for the proxy.
+- Use `--virtualbox-host-dns-resolver` option, which requires docker-machine >= 0.5.3.
 
 ### Removed
 - Remove the host dnsmasq proxy, as it now runs in Docker.

--- a/cli/dinghy/machine.rb
+++ b/cli/dinghy/machine.rb
@@ -21,14 +21,10 @@ class Machine
       $stderr.puts err
       raise("There was an error creating the VM.")
     end
-
-    configure_machine(provider)
   end
 
   def up
     unless running?
-      configure_machine(provider)
-
       out, err = System.capture_output {
         system("start", machine_name)
       }
@@ -152,20 +148,6 @@ class Machine
       "parallels"
     else
       nil
-    end
-  end
-
-  protected
-
-  def configure_machine(provider)
-    if provider == "virtualbox"
-      halt if running?
-      # force host DNS resolving, so that *.docker resolves inside containers
-      Kernel.system("VBoxManage", "modifyvm", machine_name, "--natdnshostresolver1", "on")
-
-      if System.command_failed?
-        raise("There was an error configuring the VM.")
-      end
     end
   end
 end

--- a/cli/dinghy/machine/create_options.rb
+++ b/cli/dinghy/machine/create_options.rb
@@ -5,6 +5,7 @@ module Machine::CreateOptions
       cpus: '--virtualbox-cpu-count',
       disk: '--virtualbox-disk-size',
       no_share: '--virtualbox-no-share',
+      host_dns: '--virtualbox-host-dns-resolver',
       boot2docker_url: '--virtualbox-boot2docker-url'
     }.freeze,
 
@@ -39,6 +40,7 @@ module Machine::CreateOptions
       flags[:memory], (options['memory'] || MEM_DEFAULT).to_s,
       flags[:cpus], (options['cpus'] || CPU_DEFAULT).to_s,
       flags[:disk], (options['disk'] || DISK_DEFAULT).to_s,
+      flags[:host_dns],
       flags[:no_share]
     ].compact.tap do |create_options|
       unless options['boot2docker_url'].nil?

--- a/spec/create_options_spec.rb
+++ b/spec/create_options_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe Machine::CreateOptions do
       '--virtualbox-memory', MEM_DEFAULT.to_s,
       '--virtualbox-cpu-count', CPU_DEFAULT.to_s,
       '--virtualbox-disk-size', DISK_DEFAULT.to_s,
+      '--virtualbox-host-dns-resolver',
       '--virtualbox-no-share',
     ])
   end


### PR DESCRIPTION
By using the docker-machine option, we can avoid stopping the vm right after creating it to configure it.

The option was introduced [docker-machine v0.5.3](
https://github.com/docker/machine/releases/tag/v0.5.3).