### PR TITLE
add support for custom nginx proxy config

### DIFF
--- a/cli/dinghy/http_proxy.rb
+++ b/cli/dinghy/http_proxy.rb
@@ -102,6 +102,7 @@ class HttpProxy
       "-p", "19322:19322/udp",
       "-v", "/var/run/docker.sock:/tmp/docker.sock:ro",
       "-v", "#{Dinghy.home_dinghy_certs}:/etc/nginx/certs",
+      "-v", "#{Dinghy.home_dinghy}/proxy.conf:/etc/nginx/conf.d/custom.conf",
       "-e", "CONTAINER_NAME=#{CONTAINER_NAME}",
       "-e", "DOMAIN_TLD=#{dinghy_domain}",
       "-e", "DNS_IP=#{machine.vm_ip}",


### PR DESCRIPTION
I ran into an issue that required modifying the proxy configuration to get my application to work. I noticed that according to the documentation for `nginx-proxy`, you can include additional configuration by mounting files inside /etc/nginx/conf.d

This is a one line pull request that lets you create `custom.conf` in your `.dinghy` folder and it will be mounted to the proxy container.