### PR TITLE
don't load ~/.gemrc when installing fsevents_to_vm

### DIFF
--- a/cli/dinghy/fsevents_to_vm.rb
+++ b/cli/dinghy/fsevents_to_vm.rb
@@ -29,10 +29,10 @@ class FseventsToVm
   protected
 
   def install_if_necessary!
-    %x{/System/Library/Frameworks/Ruby.framework/Versions/Current/usr/bin/gem list -i -v '#{VERSION}' fsevents_to_vm}
+    %x{/System/Library/Frameworks/Ruby.framework/Versions/Current/usr/bin/gem list --config-file '' -i -v '#{VERSION}' fsevents_to_vm}
     return if $?.success? and File.exists? BIN_PATH
     puts "Installing fsevents_to_vm, this will require sudo"
-    system!("installing", "sudo", "/System/Library/Frameworks/Ruby.framework/Versions/Current/usr/bin/gem", "install", "--no-rdoc", "--no-ri", "-n", INSTALL_PATH, "fsevents_to_vm", "-v", VERSION)
+    system!("installing", "sudo", "-H", "/System/Library/Frameworks/Ruby.framework/Versions/Current/usr/bin/gem", "install", "--no-rdoc", "--no-ri", "-n", INSTALL_PATH, "fsevents_to_vm", "-v", VERSION)
   end
 
   def increase_inotify_limit


### PR DESCRIPTION
This fix avoids loading the current user's gemrc both when probing if
`fsevents_to_vm` is installed, and when installing it. If the gem is installed
using `--env-shebang` an incorrect ruby may be located (by searching the user's
`PATH`) resulting in a failure to start the FsEvents daemon.

Related to issue #227. `~/.gemrc` contained:

```
install: --env-shebang
```