### PR TITLE
Add support for Fish

### DIFF
--- a/cli/dinghy/check_env.rb
+++ b/cli/dinghy/check_env.rb
@@ -28,9 +28,21 @@ class CheckEnv
       "DOCKER_MACHINE_NAME" => machine.name,
     }
   end
+  
+  def shell
+    begin
+        return `echo $SHELL`.strip
+    rescue
+        return
+    end
+  end
 
   def print
-    expected.each { |name,value| puts "    export #{name}=#{value}" }
+    if shell().end_with?('/fish') then
+      expected.each { |name,value| puts "    set -gx #{name} #{value}" }
+    else
+      expected.each { |name,value| puts "    export #{name}=#{value}" }
+    end
   end
 
   def set?

--- a/cli/dinghy/check_env.rb
+++ b/cli/dinghy/check_env.rb
@@ -33,7 +33,7 @@ class CheckEnv
     begin
         return `echo $SHELL`.strip
     rescue
-        return
+        return ""
     end
   end
 


### PR DESCRIPTION
The [Fish](https://fishshell.com/) (Friendly Interactive Shell) uses a different syntax to define environmental variables. This PR adds support for it.