### PR TITLE
Naive fix to pass custom host mount dir to fsevents_to_vm

### DIFF
--- a/cli/dinghy/fsevents_to_vm.rb
+++ b/cli/dinghy/fsevents_to_vm.rb
@@ -32,6 +32,7 @@ class FseventsToVmRunner
     require 'fsevents_to_vm/cli'
     args = [
       'start',
+      ENV['DINGHY_HOST_MOUNT_DIR'] || ENV['HOME'],
       "--ssh-identity-file=#{machine.ssh_identity_file_path}",
       "--ssh-ip=#{machine.vm_ip}"
     ]


### PR DESCRIPTION
The Unfs class correctly observes the DINGHY_HOST_MOUNT_DIR (+ DINGHY_GUEST_MOUNT_DIR) environment variable, but FseventsToVmRunner does not, so by default only fsevents generated in the users home directory are relayed.

This commit addresses that and allows DINGHY_HOST_MOUNT_DIR to effect the expected behaviour. 
However, my Ruby knowledge is quite rusty, so this PR should be construed as a crude fix only.